### PR TITLE
Sending Emails on Totalizer Errors and Fuel Tickets

### DIFF
--- a/fuel-kiosk/create-dev-environment.sh
+++ b/fuel-kiosk/create-dev-environment.sh
@@ -40,7 +40,7 @@ export SECRET_KEY=$(openssl rand -base64 32)
 echo "Installing Packages..."
 
 # Check if this is running in CI then do clean install
-if [ "$CI" = "true" ]; then
+if [ -n "$CI" ]; then
     echo "CI environment detected. Running npm ci..."
     npm ci || (echo "ERROR: problem installing npm packages with npm ci"; exit 1)
 else
@@ -67,4 +67,17 @@ fi
 # Setup connection URL in env file
 echo "export DATABASE_URL=$DATABASE_URL" > .dev.env
 echo "export SECRET_KEY=$SECRET_KEY" >> .dev.env
+
+echo >> .dev.env
+
+if [ -z "$EMAIL_USER" ] || [ -z "$EMAIL_PASSWORD" ]; then
+    echo "export EMAIL_USER=<<Put in your ONID username>>" >> .dev.env
+    echo "export EMAIL_PASSWORD=<<Put in your ONID password>>" >> .dev.env
+
+    echo "IMPORTANT: Emails won't work until you set your respective email credentials in the .dev.env file and source it"
+else
+    echo "export EMAIL_USER=$EMAIL_USER" >> .dev.env
+    echo "export EMAIL_PASSWORD=$EMAIL_PASSWORD" >> .dev.env
+fi
+
 echo "IMPORTANT: Before you run \`npm run dev\` you may need to run \`source .dev.env\` which will set the important envs"

--- a/fuel-kiosk/create-dev-environment.sh
+++ b/fuel-kiosk/create-dev-environment.sh
@@ -71,8 +71,8 @@ echo "export SECRET_KEY=$SECRET_KEY" >> .dev.env
 echo >> .dev.env
 
 if [ -z "$EMAIL_USER" ] || [ -z "$EMAIL_PASSWORD" ]; then
-    echo "export EMAIL_USER=<<Put in your ONID username>>" >> .dev.env
-    echo "export EMAIL_PASSWORD=<<Put in your ONID password>>" >> .dev.env
+    echo "export EMAIL_USER=\"Put in your ONID username\"" >> .dev.env
+    echo "export EMAIL_PASSWORD=\"Put in your ONID password\"" >> .dev.env
 
     echo "IMPORTANT: Emails won't work until you set your respective email credentials in the .dev.env file and source it"
 else

--- a/fuel-kiosk/cypress/e2e/verifyTotalizer.cy.js
+++ b/fuel-kiosk/cypress/e2e/verifyTotalizer.cy.js
@@ -31,17 +31,16 @@ describe('Fuel Kiosk Totalizer Verification Flow', () => {
         cy.contains('Fuel Site Entry Log').should('be.visible');
     });
 
-    it('alerts and stays on verification page when NO is clicked', () => {
+    it('generates email alert and goes to fuel entry form when NO is clicked', () => {
         cy.contains('DSL').click();
 
         const alertStub = cy.stub();
         cy.on('window:alert', alertStub);
 
-        cy.contains('NO').click().then(() => {
-            expect(alertStub).to.have.been.calledWith('Please contact administrator for assistance');
-        });
+        cy.contains('NO').click()
 
-        cy.contains('Verify Totalizer').should('be.visible');
+        cy.contains('Fuel Site Entry Log').should('be.visible');
+        cy.contains('An email alert was generated.').should('be.visible');
     });
 
     it('returns to fuel type selection when BACK is clicked', () => {

--- a/fuel-kiosk/package-lock.json
+++ b/fuel-kiosk/package-lock.json
@@ -16,6 +16,7 @@
         "@tabler/icons-react": "^3.22.0",
         "next": "15.0.3",
         "next-auth": "^4.24.11",
+        "nodemailer": "^6.10.0",
         "postcss-simple-vars": "^7.0.1",
         "prisma": "^6.3.1",
         "react": "^18.3.1",
@@ -12121,6 +12122,15 @@
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -13533,6 +13543,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"

--- a/fuel-kiosk/package.json
+++ b/fuel-kiosk/package.json
@@ -23,6 +23,7 @@
     "@tabler/icons-react": "^3.22.0",
     "next": "15.0.3",
     "next-auth": "^4.24.11",
+    "nodemailer": "^6.10.0",
     "postcss-simple-vars": "^7.0.1",
     "prisma": "^6.3.1",
     "react": "^18.3.1",

--- a/fuel-kiosk/src/app/admin/components/navbar/NavbarSimple.js
+++ b/fuel-kiosk/src/app/admin/components/navbar/NavbarSimple.js
@@ -38,10 +38,10 @@ export function NavbarSimple({ setPage }) {
                         setPage(data[0].label);
                         localStorage.setItem('siteData', JSON.stringify(data));
                     } else {
-                        console.error("Failed to fetch data from server.");
+                        alert("Failed to fetch data from server.");
                     }
                 } catch (error) {
-                    console.error("Error fetching site data:", error);
+                    alert("Error fetching site data:", error);
                 }
             }
         };

--- a/fuel-kiosk/src/app/admin/page.js
+++ b/fuel-kiosk/src/app/admin/page.js
@@ -13,7 +13,6 @@ import { NavbarSimple } from "./components/navbar/NavbarSimple";
 
 import { AdminTotalizerVerification } from './components/admintotalizer/AdminTotalizerVerification';
 import { FuelTypeSelector } from "../components/fuelselector/FuelTypeSelector";
-import { FuelEntryForm } from '../components/fuelentry/FuelEntryForm';
 
 import classes from "./admin.module.css";
 

--- a/fuel-kiosk/src/app/api/email/fuelticket/route.js
+++ b/fuel-kiosk/src/app/api/email/fuelticket/route.js
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+import { sendFuelTicketEmail } from '../../../../lib/email';
+
+// Enable revalidation for static output
+export const revalidate = 60; // Revalidate every 60 seconds
+export const dynamic = 'force-dynamic';
+
+export async function POST(req) {
+    try {
+        const emailInfo = await req.json();
+        console.log(emailInfo);
+        sendFuelTicketEmail(emailInfo.to, emailInfo.data);
+        return NextResponse.json({ message: "Email Sent Successfully" }, { status: 200 });
+    } catch (error) {
+        console.error("Email Error:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/fuel-kiosk/src/app/api/email/fuelticket/route.js
+++ b/fuel-kiosk/src/app/api/email/fuelticket/route.js
@@ -9,7 +9,6 @@ export const dynamic = 'force-dynamic';
 export async function POST(req) {
     try {
         const emailInfo = await req.json();
-        console.log(emailInfo);
         sendFuelTicketEmail(emailInfo.to, emailInfo.data);
         return NextResponse.json({ message: "Email Sent Successfully" }, { status: 200 });
     } catch (error) {

--- a/fuel-kiosk/src/app/api/email/totalizererror/route.js
+++ b/fuel-kiosk/src/app/api/email/totalizererror/route.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+import { sendTotalizerErrorEmail } from '../../../../lib/email';
+
+// Enable revalidation for static output
+export const revalidate = 60; // Revalidate every 60 seconds
+export const dynamic = 'force-dynamic';
+
+export async function POST(req) {
+    try {
+        const emailInfo = await req.json();
+        sendTotalizerErrorEmail(emailInfo.to, emailInfo.data);
+        return NextResponse.json({ message: "Email Sent Successfully" }, { status: 200 });
+    } catch (error) {
+        console.error("Email Error:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/fuel-kiosk/src/app/components/fuelentry/FuelEntryForm.js
+++ b/fuel-kiosk/src/app/components/fuelentry/FuelEntryForm.js
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import { Paper, Stack, TextInput, Select, Group, Button } from '@mantine/core';
 
-export function FuelEntryForm({ siteInfo, initialValues = {}, onSubmit }) {
+export function FuelEntryForm({ siteInfo, initialValues = {}, onSubmit, resetTotalizer }) {
     const defaultValues = {
         dateTimeInsert: new Date()
             .toLocaleString('en-US', { hour12: false })
             .replace(/,/g, ''),
         date: new Date().toLocaleDateString(),
-        totalizerStart: '',
+        totalizerStart: (resetTotalizer ? '' : initialValues.totalizerStart),
         fuelSite: `${siteInfo?.LOC_loc_code}--${siteInfo?.name}` || '',
         fuelSiteCode: siteInfo?.LOC_loc_code || '',
         fuelType: '',
@@ -45,8 +45,6 @@ export function FuelEntryForm({ siteInfo, initialValues = {}, onSubmit }) {
                 projectUnit: formData.projectUnit
             };
 
-            //console.log('Submitting data:', dataToSubmit);
-
             const response = await fetch('/api/fuel-entry', {
                 method: 'POST',
                 headers: {
@@ -69,7 +67,6 @@ export function FuelEntryForm({ siteInfo, initialValues = {}, onSubmit }) {
                 throw new Error(result.error || 'Failed to save fuel entry');
             }
         } catch (err) {
-            console.error('Submission error:', err);
             setError(err.message);
         } finally {
             setIsSubmitting(false);
@@ -78,9 +75,9 @@ export function FuelEntryForm({ siteInfo, initialValues = {}, onSubmit }) {
 
     const handleReset = () => {
         setFormData({
-            ...defaultValues,
             dateTimeInsert: new Date().toLocaleString('en-US', { hour12: false }),
             date: new Date().toLocaleDateString(),
+            ...defaultValues,
         });
         setError(null);
     };
@@ -95,28 +92,46 @@ export function FuelEntryForm({ siteInfo, initialValues = {}, onSubmit }) {
                         </div>
                     )}
 
+                    { resetTotalizer && (
+                        <div>
+                            <h2><p>An email alert was generated.</p></h2>
+                            <p>Please continue and update the starting totalizer reading.</p>
+                        </div>
+                    )}
+
                     <TextInput
                         label="Date/Time Insert"
                         value={formData.dateTimeInsert || ''}
-                        readOnly
+                        disabled
                     />
                     <TextInput
                         label="Date"
                         value={formData.date || ''}
-                        readOnly
+                        disabled
                     />
-                    <TextInput
-                        label="Totalizer Start (xxx.x)"
-                        value={formData.totalizerStart}
-                        onChange={(e) =>
-                            setFormData({ ...formData, totalizerStart: e.target.value })
-                        }
-                        required
-                    />
+                    { resetTotalizer ? (
+                        <TextInput
+                            label="Totalizer Start (xxx.x)"
+                            placeholder='Update Totalizer Start...'
+                            onChange={(e) =>
+                                setFormData({ ...formData, totalizerStart: e.target.value })
+                            }
+                            required
+                        />
+                    ) : (
+                        <TextInput
+                            label="Totalizer Start (xxx.x)"
+                            value={formData.totalizerStart}
+                            onChange={e => e.preventDefault()}
+                            disabled
+                            required
+                        />
+
+                    )}
                     <TextInput
                         label="Fuel Site"
                         value={formData.fuelSite}
-                        readOnly
+                        disabled
                     />
                     <TextInput
                         label="Fuel Type"

--- a/fuel-kiosk/src/app/components/login/Login.js
+++ b/fuel-kiosk/src/app/components/login/Login.js
@@ -36,10 +36,10 @@ export function Login(){
                         setSiteData(formattedSites);
                         localStorage.setItem('siteData', JSON.stringify(formattedSites)); // Cache data locally
                     } else {
-                        console.error("Failed to fetch data from server.");
+                        alert("Failed to fetch data from server.")
                     }
                 } catch (error) {
-                    console.error("Error fetching site data:", error);
+                    alert("Error fetching site data:", error);
                 }
             }
         };

--- a/fuel-kiosk/src/app/input-form/page.js
+++ b/fuel-kiosk/src/app/input-form/page.js
@@ -13,16 +13,16 @@ async function fetchFuelData() {
         return data;
     } else{
         return (123.45, ['Site A', 'Site B', 'Site C'])
-               
-            
-          
+
+
+
     }
 
   } catch(error) {
     console.error("Error fetching fuel data", error)
   }
   return (123.45, ['Site A', 'Site B', 'Site C'])
-  
+
 }
 
 export default async function Page() {
@@ -30,7 +30,6 @@ export default async function Page() {
   const { previousMax, fuelSites } = await fetchFuelData();
 
   const handleFormSubmit = (formData) => {
-    console.log('Form submitted with data:', formData);
     // Example: send formData to your backend
     fetch('/api/submit-fuel-data', {
       method: 'POST',

--- a/fuel-kiosk/src/lib/email.js
+++ b/fuel-kiosk/src/lib/email.js
@@ -1,0 +1,67 @@
+import { createTransport } from 'nodemailer';
+
+import { FuelTicketEmail } from './emailTemplates/FuelTicketEmail';
+import { TotalizerErrorEmail } from './emailTemplates/TotalizerErrorEmail';
+
+const transporter = createTransport({
+    host: "mail.engr.oregonstate.edu",
+    port: 465,
+    secure: true,
+    auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASSWORD,
+    },
+    tls: {
+        ciphers: 'SSLv3',
+    },
+})
+
+export async function sendEmailText(to, subject, text) {
+    try {
+        const info = await transporter.sendMail({
+            from: `"Fuel Kiosk" <${process.env.EMAIL_USER}>`,
+            to,
+            subject,
+            text,
+        });
+
+        console.log(`Email sent: ${info.messageId}`);
+    } catch (error) {
+        console.error("Error sending email:", error);
+    }
+}
+
+export async function sendEmailHTML(to, subject, html) {
+    try {
+        const info = await transporter.sendMail({
+            from: `"Fuel Kiosk" <${process.env.EMAIL_USER}>`,
+            to,
+            subject,
+            html,
+        });
+
+        console.log(`Email sent: ${info.messageId}`);
+    } catch (error) {
+        console.error("Error sending email:", error);
+    }
+}
+
+export async function sendFuelTicketEmail(to, data) {
+    const ReactDomServer = (await import('react-dom/server')).default;
+
+    const emailHTML = ReactDomServer.renderToStaticMarkup(
+        <FuelTicketEmail {...data} />
+    );
+
+    sendEmailHTML(to, `Fuel Ticket: ${data.loc_code}${data.eq_no ? `-${data.eq_no}` : ''}`, emailHTML);
+}
+
+export async function sendTotalizerErrorEmail(to, data) {
+    const ReactDomServer = (await import('react-dom/server')).default;
+
+    const emailHTML = ReactDomServer.renderToStaticMarkup(
+        <TotalizerErrorEmail {...data} />
+    );
+
+    sendEmailHTML(to, 'Totalizer Reading Error', emailHTML);
+}

--- a/fuel-kiosk/src/lib/emailTemplates/FuelTicketEmail.js
+++ b/fuel-kiosk/src/lib/emailTemplates/FuelTicketEmail.js
@@ -1,0 +1,56 @@
+import React from "react";
+
+export function FuelTicketEmail({
+    datetime_Insert,
+    ftk_date,
+    loc_code,
+    fuel_type,
+    totalizer_start,
+    eq_no,
+    pid_info,
+    odometer,
+    qty_fuel,
+    totalizer_end,
+    acct_code,
+    business_purpose,
+    totalizer_update
+
+}) {
+    return (
+        <html>
+            <head>
+                <style type="text/css">
+                    {`
+                        body { font-family: Arial, Helvetica, sans-serif; }
+                        table { border-collapse: collapse; width: 100%; }
+                        td { border: 1px solid black; padding: 5px; }
+                        b { font-size: 16px; }
+                    `}
+                </style>
+            </head>
+            <body>
+                <table>
+                    <tr><td colSpan="2"><b>Fuel Site Entry Log</b></td></tr>
+                    <tr><td>Date/Time Insert:</td><td>{datetime_Insert}</td></tr>
+                    <tr><td>Date:</td><td>{ftk_date}</td></tr>
+                    <tr><td>Totalizer Start:</td><td>{totalizer_start}</td></tr>
+                    <tr><td>Fuel Site:</td><td>{loc_code}</td></tr>
+                    <tr><td>Fuel Type:</td><td>{fuel_type}</td></tr>
+                    <tr><td>Veh ID:</td><td>{eq_no}</td></tr>
+                    <tr><td>PID Info:</td><td>{pid_info}</td></tr>
+                    <tr><td>Odometer:</td><td>{odometer}</td></tr>
+                    <tr><td>Gallons Pumped:</td><td>{qty_fuel}</td></tr>
+                    <tr><td>Totalizer End:</td><td>{totalizer_end}</td></tr>
+                    <tr><td>Index-Activity:</td><td>{acct_code}</td></tr>
+                    <tr><td>Business Purpose:</td><td>{business_purpose}</td></tr>
+                    <tr><td>Totalizer Update:</td><td>{totalizer_update}</td></tr>
+                </table>
+                <p>Thank You,<br />
+                    Motor Pool<br /><br />
+                    (541) 737-4141 Phone<br />
+                    <a href="mailto:motorpool@oregonstate.edu">motorpool@oregonstate.edu</a>
+                </p>
+            </body>
+        </html>
+    );
+}

--- a/fuel-kiosk/src/lib/emailTemplates/TotalizerErrorEmail.js
+++ b/fuel-kiosk/src/lib/emailTemplates/TotalizerErrorEmail.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+
+export function TotalizerErrorEmail({
+    fuel_site,
+    fuel_type,
+}) {
+    return (
+        <html>
+            <style type="text/css"> {`
+                body { font-family: Arial, Helvetica, sans-serif;
+            `}
+            </style>
+            <body>
+                <p>There is a user generated flag for beginning totalizer reading at {fuel_site} for {fuel_type}.</p>
+                <p>The user will be prompted to enter a corrected totalizer starting number.</p>
+
+                <p>Thank You,<br />
+                Motor Pool<br /><br />
+                (541) 737-4141  Phone<br />
+                <a href="mailto:motorpool@oregonstate.edu">motorpool@oregonstate.edu</a></p>
+            </body>
+        </html>
+    );
+}

--- a/fuel-kiosk/src/middleware.js
+++ b/fuel-kiosk/src/middleware.js
@@ -16,7 +16,7 @@ export default async function middleware(req) {
         return NextResponse.redirect(new URL('/', req.nextUrl))
     }
 
-    if (userId && userId !== 'ADMIN' && !path.includes(userId)) {
+    if (userId && userId !== 'ADMIN' && !path.includes(userId) && !path.includes('transactions')) {
         return NextResponse.redirect(new URL(`/sites/${userId}`, req.nextUrl))
     }
 

--- a/fuel-kiosk/test-utils/test-data/LOC_MAIN.json
+++ b/fuel-kiosk/test-utils/test-data/LOC_MAIN.json
@@ -2,73 +2,73 @@
     {
         "LOC_loc_code": "ADMIN",
         "name": "FUEL SITE ADMINISTRATOR",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "CBARC-M",
         "name": "COLUMBIA BASIN AG RESEARCH-MOR",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "CBARC-P",
         "name": "COLUMBIA BASIN AG RESEARCH-PEN",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "COAREC",
         "name": "CENTRAL OREGON AG RES EXT",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "DAIRY",
         "name": "CORVALLIS",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "EOARC-B",
         "name": "EASTERN OREGON AG RESEARCH",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "EOARC-U",
         "name": "EASTERN OREGON AG RESEARCH",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "HAREC",
         "name": "HERMISTON AG RESEARCH STATION",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "KBREC",
         "name": "KLAMATH BASIN EXPERIMENT STA",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "MES",
         "name": "MALHEUR EXPERIMENT STATION",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "SOREC",
         "name": "SOUTHERN OREGON RES EXT CTR",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     },
     {
         "LOC_loc_code": "NWREC",
         "name": "NORTH WILLAMETTE RES EXTEN CTR",
-        "email_addr": "fueldepot@example.com",
+        "email_addr": "fuelkiosk@outlook.com",
         "is_fuel_site": true
     }
 ]


### PR DESCRIPTION
## About:
The original application would generate email alerts for totalizer errors to indicate a possible theft or to keep track of fuel submissions. The emails would be sent to the corresponding contact email address for the location. This PR entails the implementation of that. I use the Oregon State University ENGR SMTP server and authenticate through ONID.

## Changes:
* Added nodemailer and setup SMTP on the OSU ENGR server, and set the auth to use the EMAIL_USER and EMAIL_PASSWORD env vars.
* Setup a test outlook account called `fuelkiosk@outlook.com` (creds can be found in discord). Also changed all LOC_MAIN entries in our test data to use the `fuelkiosk@outlook.com` testing email as their contact email. This means that all emails alerts will go there when testing locally.
* Setup Email templates for and setup email functions so that email alerts could be generated easily.
* Setup API routes to actually send emails so that the client could actually indicate that an email needs to be sent via the server.
* Updated create-dev-environment script to put the EMAIL_USER and EMAIL_PASSWORD in the .dev.env file along with some other logic.
* Updated the site-pages to work as the original site does (When "NO" is pressed on totalizer verification an email is sent and it goes to the entry page with a non-existent totalizer start).
* Cleaned up some of the code base and unneeded log statements.