### PR TITLE
Added alert mechanism for when fuel flows without an accompanying ticket

### DIFF
--- a/fuel-kiosk/.gitignore
+++ b/fuel-kiosk/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 
 public/sw*
 public/swe-worker*
+
+# python
+.venv/

--- a/fuel-kiosk/package-lock.json
+++ b/fuel-kiosk/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "serwist": "^9.0.12",
+        "socket.io-client": "^4.8.1",
         "start-server-and-test": "^2.0.8"
       },
       "devDependencies": {
@@ -3565,6 +3566,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@storybook/builder-webpack5": {
       "version": "8.4.5",
@@ -7642,6 +7649,49 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.1",
@@ -14792,6 +14842,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -16881,6 +16959,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/fuel-kiosk/package.json
+++ b/fuel-kiosk/package.json
@@ -31,6 +31,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "serwist": "^9.0.12",
+    "socket.io-client": "^4.8.1",
     "start-server-and-test": "^2.0.8"
   },
   "devDependencies": {

--- a/fuel-kiosk/src/app/api/email/fuelflowerror/route.js
+++ b/fuel-kiosk/src/app/api/email/fuelflowerror/route.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+import { sendFuelFlowErrorEmail } from '../../../../lib/email';
+
+// Enable revalidation for static output
+export const revalidate = 60; // Revalidate every 60 seconds
+export const dynamic = 'force-dynamic';
+
+export async function POST(req) {
+    try {
+        const emailInfo = await req.json();
+        sendFuelFlowErrorEmail(emailInfo.to, emailInfo.data);
+        return NextResponse.json({ message: "Email Sent Successfully" }, { status: 200 });
+    } catch (error) {
+        console.error("Email Error:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/fuel-kiosk/src/app/components/context/FuelFlowProvider.js
+++ b/fuel-kiosk/src/app/components/context/FuelFlowProvider.js
@@ -1,0 +1,38 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+
+export const FuelFlowContext = createContext();
+
+export function FuelFlowProvider({ children }) {
+    const [socket, setSocket] = useState();
+    const [timeoutID, setTimeoutID] = useState(null);
+
+    useEffect(() => {
+        // const socketInstance = io("http://localhost:3005");  for different server websocket url
+        const socketInstance = io(`http://localhost:4097`);
+
+        setSocket(socketInstance);
+
+        return () => {
+            socketInstance.disconnect();
+        };
+    }, []);
+
+    return (
+        <FuelFlowContext.Provider value={{ socket: [socket, setSocket], timeoutID: [timeoutID, setTimeoutID] }}>
+          {children}
+        </FuelFlowContext.Provider>
+      );
+}
+
+//export { SocketContext, SocketProvider }
+
+/*export const useSocket = () => {
+    const context = useContext(SocketContext);
+    if (!context) {
+      throw new Error('useSocket must be used within a SocketProvider');
+    }
+    return context.socket;
+  };*/

--- a/fuel-kiosk/src/app/components/dashboard/contents/FuelFlowStatus.js
+++ b/fuel-kiosk/src/app/components/dashboard/contents/FuelFlowStatus.js
@@ -1,0 +1,79 @@
+import { useState, useEffect, useContext } from "react";
+import { Button, ActionIcon } from "@mantine/core";
+import { FuelFlowProvider, FuelFlowContext } from "../../context/FuelFlowProvider";
+
+export function FuelFlowStatus({loc_code}) {
+
+    const { socket, timeoutID } = useContext(FuelFlowContext);
+    const [socketValue, setSocketValue] = socket;
+    const [timeoutIDValue, setTimeoutIDValue] = timeoutID;
+
+    //const socket = useSocket();
+    const [flowState, setFlowState] = useState(0);
+
+    function getLookbackDatetime(currentTimestamp) {
+        let lookbackTimestamp = currentTimestamp - 480000;          //8min lookback
+        let lookbackDateStart = new Date(lookbackTimestamp);
+        //let lookbackDateStart = new Date(lookbackTimestamp - 86400000);         //+ 1 day bc of quirky filter
+        let lookbackDateEnd = new Date(lookbackTimestamp + 86400000);
+        const formattedLookbackDateStart = lookbackDateStart.toISOString().split('T')[0];
+        const formattedLookbackDateEnd = lookbackDateEnd.toISOString().split('T')[0];
+
+        return {
+            startDate: formattedLookbackDateStart,
+            endDate: formattedLookbackDateEnd,
+            lookbackTimestamp: lookbackTimestamp
+        }
+    }
+
+    useEffect(() => {
+        if (!socketValue) return;
+        console.log("Socket connected");
+        console.log(loc_code);
+
+        socketValue.on("sendFlowState", (newFlowState) => {
+            console.log(`FLOW STATE: ${JSON.stringify(newFlowState)}`);
+            
+            if ((flowState == 0) && (newFlowState['data'] == 1)) {
+                setTimeoutIDValue(setTimeout(async () => {
+                    const currentTimestamp = Date.now();
+                    const { startDate, endDate, lookbackTimestamp } = getLookbackDatetime(currentTimestamp);
+                    if (loc_code) {
+                        const queryString = `/api/transactions?loc_code=${loc_code}&start=${startDate}&end=${endDate}`;
+                        console.log(`FUEL FLOW QUERY: ${queryString}`);
+                        let results = null;
+                        try {
+                            const response = await fetch(queryString);
+                            results = await response.json();
+                            let recentLogs = results.filter((log, index) => {
+                                const logTimestamp = new Date(log['datetime_Insert']).getTime()
+                                return (logTimestamp > lookbackTimestamp) 
+                            })
+                            console.log(recentLogs);
+                            if (!recentLogs || recentLogs.length === 0) {
+                                alert("Fuel flow - No ticket")
+                            }
+                        } catch (error) {
+                            console.error("Error fetching logs:", error);
+                        }
+                        console.log(JSON.stringify(results));
+                    }
+                }, 5000));
+            }
+            setFlowState(newFlowState['data']);
+        });
+
+        return () => {
+            socketValue.off("sendFlowState");
+        };
+
+    }, [socketValue]);
+
+    return (
+        <div style={{ height: "100%", width: "100%", display: "flex", justifyContent: "center", alignItems: "center" }}>
+            <ActionIcon style={{ height: "100%", width: "100%" }} radius="md" variant="light" color="rgb(201, 201, 201)">
+                <p style={{ fontSize: "20pt" }}>Fuel Flow {(flowState === 1) ? "On" : "Off"}</p>
+            </ActionIcon>
+        </div>
+    )
+}

--- a/fuel-kiosk/src/app/components/dashboard/contents/FuelFlowStatus.js
+++ b/fuel-kiosk/src/app/components/dashboard/contents/FuelFlowStatus.js
@@ -13,7 +13,7 @@ export function FuelFlowStatus({loc_code, site_email_addr}) {
     const [flowStartTimestamp, setFlowStartTimestamp] = useState(0);
 
     function getLookbackDatetime(currentTimestamp) {
-        let lookbackTimestamp = currentTimestamp - 5000//480000;          //8min lookback
+        let lookbackTimestamp = currentTimestamp - 15000//480000;          //8min lookback in ms
         let lookbackDateStart = new Date(lookbackTimestamp);
         //let lookbackDateStart = new Date(lookbackTimestamp - 86400000);         //+ 1 day bc of quirky filter
         let lookbackDateEnd = new Date(lookbackTimestamp + 86400000);
@@ -76,7 +76,7 @@ export function FuelFlowStatus({loc_code, site_email_addr}) {
                         }
                         console.log(JSON.stringify(results));
                     }
-                }, 5000));
+                }, 5000));                  // Timer in ms
             }
             setFlowState(newFlowState['data']);
         });

--- a/fuel-kiosk/src/app/layout.js
+++ b/fuel-kiosk/src/app/layout.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MantineProvider, Center } from "@mantine/core";
 import '@mantine/core/styles.css';
+import { FuelFlowProvider } from "./components/context/FuelFlowProvider"
 // import {metadata} from "/fuel-kiosk-dc/fuel-kiosk/src/app/manifest"
 
 import classes from './app.module.css';
@@ -48,11 +49,13 @@ export default function RootLayout({ children }) {
             {/* <link rel="manifest" href="/manifest.json"></link> */}
             </head>
             <body className={classes.base} >
+              <FuelFlowProvider>
                 <MantineProvider defaultColorScheme="dark">
                     <Center className={classes.center}>
                         {children}
                     </Center>
                 </MantineProvider>
+              </FuelFlowProvider>
             </body>
         </html>
     );

--- a/fuel-kiosk/src/app/page.js
+++ b/fuel-kiosk/src/app/page.js
@@ -4,6 +4,7 @@ import { LeadGrid } from "./components/dashboard/leadgrid/LeadGrid";
 import { Login } from "./components/login/Login";
 import {AdminPageButton} from "./components/dashboard/contents/AdminPageButton"
 import {InputFormButton} from "./components/dashboard/contents/InputFormButton"
+import {FuelFlowStatus} from "./components/dashboard/contents/FuelFlowStatus"
 
 import classes from "./app.module.css";
 
@@ -18,7 +19,8 @@ export default function Home() {
                     secondaryBottomLeftContent={<AdminPageButton/>}
                     // Fuel Input Form Page
                     secondaryTopContent={<InputFormButton/>}
-                    
+                    // Fuel Flow Status
+                    secondaryBottomRightContent={<FuelFlowStatus />}
                 />
             </main>
         </div>

--- a/fuel-kiosk/src/app/sites/[loc_code]/page.js
+++ b/fuel-kiosk/src/app/sites/[loc_code]/page.js
@@ -108,7 +108,7 @@ export default function FuelSitePage({ params: paramsPromise }) {
             {siteInfo ? (
                 <Stack spacing="lg">
                     <Title order={1}>{siteInfo.LOC_loc_code}--{siteInfo.name}</Title>
-                    <FuelFlowStatus loc_code={loc_code}/>
+                    <FuelFlowStatus loc_code={loc_code} site_email_addr={siteInfo.email_addr}/>
                     {step === 'SELECT_FUEL' && (
                         <Stack spacing="md">
                             <Title order={2}>Select Fuel Type</Title>

--- a/fuel-kiosk/src/app/sites/[loc_code]/page.js
+++ b/fuel-kiosk/src/app/sites/[loc_code]/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, use } from 'react';
+import React, { useContext, useState, useEffect, use } from 'react';
 import { useRouter } from 'next/navigation';
 import {
     Container,
@@ -16,6 +16,8 @@ import {
 import { FuelTypeSelector } from '../../components/fuelselector/FuelTypeSelector';
 import { TotalizerVerification } from '../../components/totalizer/TotalizerVerification';
 import { FuelEntryForm } from '../../components/fuelentry/FuelEntryForm';
+import { FuelFlowStatus } from '../../components/dashboard/contents/FuelFlowStatus';
+import { FuelFlowContext } from "../../components/context/FuelFlowProvider";
 
 export default function FuelSitePage({ params: paramsPromise }) {
     const router = useRouter();
@@ -33,6 +35,10 @@ export default function FuelSitePage({ params: paramsPromise }) {
 
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+
+    const { socket, timeoutID } = useContext(FuelFlowContext);
+    const [socketValue, setSocketValue] = socket;
+    const [timeoutIDValue, setTimeoutIDValue] = timeoutID;
 
     useEffect(() => {
         const fetchSiteInfo = async () => {
@@ -102,7 +108,7 @@ export default function FuelSitePage({ params: paramsPromise }) {
             {siteInfo ? (
                 <Stack spacing="lg">
                     <Title order={1}>{siteInfo.LOC_loc_code}--{siteInfo.name}</Title>
-
+                    <FuelFlowStatus loc_code={loc_code}/>
                     {step === 'SELECT_FUEL' && (
                         <Stack spacing="md">
                             <Title order={2}>Select Fuel Type</Title>
@@ -174,6 +180,7 @@ export default function FuelSitePage({ params: paramsPromise }) {
                                         },
                                         body: JSON.stringify(emailData)
                                     });
+                                    clearTimeout(timeoutIDValue);
 
                                     setStep('SELECT_FUEL');
                                     setResetTotalizer(false);

--- a/fuel-kiosk/src/lib/email.js
+++ b/fuel-kiosk/src/lib/email.js
@@ -2,6 +2,7 @@ import { createTransport } from 'nodemailer';
 
 import { FuelTicketEmail } from './emailTemplates/FuelTicketEmail';
 import { TotalizerErrorEmail } from './emailTemplates/TotalizerErrorEmail';
+import { UnexpectedFuelFlowEmail } from './emailTemplates/UnexpectedFuelFlowEmail';
 
 const transporter = createTransport({
     host: "mail.engr.oregonstate.edu",
@@ -64,4 +65,14 @@ export async function sendTotalizerErrorEmail(to, data) {
     );
 
     sendEmailHTML(to, 'Totalizer Reading Error', emailHTML);
+}
+
+export async function sendFuelFlowErrorEmail(to, data) {
+    const ReactDomServer = (await import('react-dom/server')).default;
+
+    const emailHTML = ReactDomServer.renderToStaticMarkup(
+        <UnexpectedFuelFlowEmail {...data} />
+    );
+
+    sendEmailHTML(to, `Unexpected Fuel Flow: ${data.loc_code}`, emailHTML);
 }

--- a/fuel-kiosk/src/lib/emailTemplates/UnexpectedFuelFlowEmail.js
+++ b/fuel-kiosk/src/lib/emailTemplates/UnexpectedFuelFlowEmail.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+
+export function UnexpectedFuelFlowEmail({
+    fuel_site,
+    timestamp,
+}) {
+    let localDate = new Date(timestamp);
+    return (
+        <html>
+            <style type="text/css"> {`
+                body { font-family: Arial, Helvetica, sans-serif;
+            `}
+            </style>
+            <body>
+                <p>There was unexpected fuel flow at {fuel_site} at time {localDate.toLocaleString()}.</p>
+                <p>Please double check for any errors.</p>
+
+                <p>Thank You,<br />
+                Motor Pool<br /><br />
+                (541) 737-4141  Phone<br />
+                <a href="mailto:motorpool@oregonstate.edu">motorpool@oregonstate.edu</a></p>
+            </body>
+        </html>
+    );
+}


### PR DESCRIPTION
The FuelFlowContext provides a global context containing the socket to listen to and the current timer. These can be accessed anywhere in the application. The default port is 4097.

The FuelFlowStatus component listens for a SocketIO event of type "sendFlowState" to detect fuel flow transitions. When fuel flow transitions from off to on a 5 minute timer is started. Successfully submitting a fuel transaction will clear the timer. 

When the timer ends the FuelFlowStatus component checks the database for any new entries within 8 minutes (3 minutes compensation for walking from the kiosk to the pump). If there are no eligible entries an alert will pop up

TODO: 

- Get the mock sensor broadcaster to work on Linux and add it to the repo
- ~~Make the alert send an actual email to the admin~~
- Write tests